### PR TITLE
Version 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,58 @@
 # Just a Compiler
 
-This is a repo for the Just Compiler. A compiler for **Just a language**. It is a turing complete JVM laguage built using java. The projuct is just for fun no serious devolepment inteded. The world do not need a new JVM language, let a lone one made using java.
+This is a repo for the **Just Compiler**. A compiler for **Just language**. It is a turing complete JVM laguage built using java. The projuct is just for fun no serious devolepment inteded. The world do not need a new JVM language, let a lone one made using java.
 
 ## New in this version
-It is now possible to use multi lines in one expression. The interpretor is also capable of showing the line number and the charachter number of the error if any:
+It is now possible to use blocks and properly declare variablers using the key word "var". The output is the result of the last expression:
 ```bash
-Just> 5+2+
-|     12
-19
+Just> {
+|       var a = 5
+|       a = a *2
+|     }
+10
+```
 
-Just> 5+  
-|     3+
-|     1-
-|     6
-3
-
-Just> a = 8
+It is also possible to declare variable in read only mode using the key word "let":
+```bash
+Just> let a = 8
 8
 
-Just> a+
-|     b
+Just> a = 5
 
-[2,1]: Variable b doesn't exist
+[1,3]: Variable 'a' is read-only and cannotbe assigned to.
+    a = 5
 ```
+
+
+**Just** now support porper scoping, it is not possible to redeclare variable in the same scope or to acces variable out of scope:
+```bash
+Just> {
+|       var a = 5
+|       {
+|         var a = true 
+|       }     
+|     }
+true
+
+Just> { 
+|       var a = 5
+|       var a = 6
+|     }
+
+[3,7]: Variable 'a' is already declared.
+      var a = 6
+
+Just> {
+|       {              
+|         var x = 1
+|       }
+|       x = 2
+|     }
+
+[5,3]: Variable x doesn't exist.
+      x = 2
+```
+
 
 
 ## features
@@ -33,3 +63,18 @@ For now this is just an expression evaluator not a compiler. It support only two
 - Logical operations: ==, !=, ! 
 - variables and assignments: a=5, 2+a
 - Print the ASL tree
+- Multi-line input
+- Print diagnostics with error postision and highligt the error
+
+
+## Setup
+
+### Requirements 
+- Java JDK 11 
+- Maven 3.6
+
+### Run
+```bash
+mvn install
+java -jar target/JustCompiler-0.4-SNAPSHOT.jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mycompany</groupId>
     <artifactId>JustCompiler</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
@@ -48,6 +48,22 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <!-- Build an executable JAR -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <classpathPrefix>lib/</classpathPrefix>
+                        <mainClass>com.JsonAjax.justcompiler.Index</mainClass>
+                    </manifest>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundBlockStatement.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundBlockStatement.java
@@ -1,0 +1,27 @@
+package com.JsonAjax.justcompiler.Binding;
+
+import java.util.List;
+
+public class BoundBlockStatement extends BoundStatement{
+
+    private List<BoundStatement> statements;
+
+    
+    public BoundBlockStatement(List<BoundStatement> statements) {
+        this.statements = statements;
+    }
+
+    
+
+    @Override
+    public BoundNodeKind getKind() {
+        return BoundNodeKind.blockStatment;
+    }
+
+
+
+    public List<BoundStatement> getStatements() {
+        return statements;
+    }
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundExpressionStatement.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundExpressionStatement.java
@@ -1,0 +1,26 @@
+package com.JsonAjax.justcompiler.Binding;
+
+public class BoundExpressionStatement extends BoundStatement{
+
+    private BoundExpression expression;
+
+    
+
+    public BoundExpressionStatement(BoundExpression expression) {
+        this.expression = expression;
+    }
+
+
+
+    @Override
+    public BoundNodeKind getKind() {
+        return BoundNodeKind.expressionStatement;
+    }
+
+
+
+    public BoundExpression getExpression() {
+        return expression;
+    }
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundGlobalScope.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundGlobalScope.java
@@ -1,0 +1,47 @@
+package com.JsonAjax.justcompiler.Binding;
+
+import java.util.List;
+
+import com.JsonAjax.justcompiler.Diagnostic;
+import com.JsonAjax.justcompiler.DiagnosticsBag;
+import com.JsonAjax.justcompiler.VariableSymbol;
+
+public class BoundGlobalScope {
+    
+    private DiagnosticsBag diagnostics;
+    private List<VariableSymbol> variables;
+    private BoundExpression expression;
+    private BoundGlobalScope previous;
+    
+    
+    public BoundGlobalScope(BoundGlobalScope previous, DiagnosticsBag diagnostics, List<VariableSymbol> variables, BoundExpression expression) {
+        this.diagnostics = diagnostics;
+        this.variables = variables;
+        this.expression = expression;
+        this.previous = previous;
+    }
+
+
+    public DiagnosticsBag getDiagnostics() {
+        return diagnostics;
+    }
+
+
+    public List<VariableSymbol> getVariables() {
+        return variables;
+    }
+
+
+    public BoundExpression getExpression() {
+        return expression;
+    }
+
+
+    public BoundGlobalScope getPrevious() {
+        return previous;
+    }
+    
+    
+
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundGlobalScope.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundGlobalScope.java
@@ -10,14 +10,14 @@ public class BoundGlobalScope {
     
     private DiagnosticsBag diagnostics;
     private List<VariableSymbol> variables;
-    private BoundExpression expression;
+    private BoundStatement statement;
     private BoundGlobalScope previous;
     
     
-    public BoundGlobalScope(BoundGlobalScope previous, DiagnosticsBag diagnostics, List<VariableSymbol> variables, BoundExpression expression) {
+    public BoundGlobalScope(BoundGlobalScope previous, DiagnosticsBag diagnostics, List<VariableSymbol> variables, BoundStatement statement) {
         this.diagnostics = diagnostics;
         this.variables = variables;
-        this.expression = expression;
+        this.statement = statement;
         this.previous = previous;
     }
 
@@ -32,8 +32,8 @@ public class BoundGlobalScope {
     }
 
 
-    public BoundExpression getExpression() {
-        return expression;
+    public BoundStatement getStatement() {
+        return statement;
     }
 
 

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundNodeKind.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundNodeKind.java
@@ -1,6 +1,12 @@
 package com.JsonAjax.justcompiler.Binding;
 
 public enum BoundNodeKind {
-    UnaryExpression, LiteralExpression, BinaryExpression, VariableExpression, AssignmentExpression
+    
+    //statments
+    blockStatment,
+    expressionStatement, 
+
+    //expressions
+    UnaryExpression, LiteralExpression, BinaryExpression, VariableExpression, AssignmentExpression, 
     
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundNodeKind.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundNodeKind.java
@@ -4,9 +4,10 @@ public enum BoundNodeKind {
     
     //statments
     blockStatment,
-    expressionStatement, 
+    expressionStatement,
+    BoundVariableDeclaration,
 
     //expressions
-    UnaryExpression, LiteralExpression, BinaryExpression, VariableExpression, AssignmentExpression, 
+    UnaryExpression, LiteralExpression, BinaryExpression, VariableExpression, AssignmentExpression,
     
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundScope.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundScope.java
@@ -1,0 +1,49 @@
+package com.JsonAjax.justcompiler.Binding;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.JsonAjax.justcompiler.VariableSymbol;
+
+public class BoundScope {
+    private Map<String,VariableSymbol> variables = new HashMap<>();
+    private BoundScope parent;
+    
+    
+    public BoundScope(BoundScope parent){
+        this.parent = parent;
+    }
+
+    
+
+    public BoundScope getParent() {
+        return parent;
+    }
+
+
+
+    public Optional<VariableSymbol> tryLookup(String name){
+        if(variables.containsKey(name))
+            return Optional.of(variables.get(name));
+        
+        if(parent == null)
+            return Optional.empty();
+        
+        return parent.tryLookup(name);
+    }
+
+    public boolean tryDeclare(VariableSymbol variable){
+        if(variables.containsKey(variable.getName()))
+            return false;
+
+        variables.put(variable.getName(), variable);
+        return true;
+    }
+
+    public List<VariableSymbol> getDeclaredVariables(){
+        return new ArrayList<>(variables.values());
+    }
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundStatement.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundStatement.java
@@ -1,0 +1,4 @@
+package com.JsonAjax.justcompiler.Binding;
+
+public abstract class BoundStatement extends BoundNode{
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Binding/BoundVariableDeclaration.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Binding/BoundVariableDeclaration.java
@@ -1,0 +1,36 @@
+package com.JsonAjax.justcompiler.Binding;
+
+import com.JsonAjax.justcompiler.VariableSymbol;
+
+public class BoundVariableDeclaration extends BoundStatement{
+
+    VariableSymbol variable;
+    BoundExpression initialiser;
+
+    
+    
+    public VariableSymbol getVariable() {
+        return variable;
+    }
+
+
+
+    public BoundExpression getInitialiser() {
+        return initialiser;
+    }
+
+
+
+    public BoundVariableDeclaration(VariableSymbol variable, BoundExpression initialiser) {
+        this.variable = variable;
+        this.initialiser = initialiser;
+    }
+
+
+
+    @Override
+    public BoundNodeKind getKind() {
+        return BoundNodeKind.BoundVariableDeclaration;
+    }
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Compilation.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Compilation.java
@@ -4,36 +4,56 @@ import java.util.Map;
 
 import com.JsonAjax.justcompiler.Binding.Binder;
 import com.JsonAjax.justcompiler.Binding.BoundExpression;
+import com.JsonAjax.justcompiler.Binding.BoundGlobalScope;
+import com.JsonAjax.justcompiler.Syntax.SyntaxToken;
 import com.JsonAjax.justcompiler.Syntax.SyntaxTree;
 
 public class Compilation {
+    
     private SyntaxTree syntax;
+    private Compilation previous;
+    private BoundGlobalScope globalScope;
 
     public Compilation(SyntaxTree syntax) {
+        this(null, syntax);
+    }
+
+    private Compilation(Compilation previous, SyntaxTree syntax){
         this.syntax = syntax;
+        this.previous = previous;
     }
 
     public SyntaxTree getSyntax() {
         return syntax;
     }
 
+    public Compilation continueWith(SyntaxTree syntax ){
+        return new Compilation(this, syntax);
+    }
+
     public EvaluationResult evaluate(Map<VariableSymbol,Object> variables){
-        Binder binder = new Binder(variables);
-        BoundExpression boundExpression;
+        
+        
         try {
-            boundExpression = binder.bindExpression(syntax.getRoot().getExpression());
+            if (globalScope == null)
+                if(previous == null)
+                    globalScope = Binder.bindGlobalScope(null, syntax.getRoot());
+                else
+                    globalScope = Binder.bindGlobalScope(previous.globalScope, syntax.getRoot());
+            syntax.getDiagnostics().addAll(globalScope.getDiagnostics());
         } catch (Exception e) {
             e.printStackTrace();
-            return new EvaluationResult(binder.getDiagnostics(),null);
+            return new EvaluationResult(syntax.getDiagnostics(),null);
         }
         
-        syntax.getDiagnostics().addAll(binder.getDiagnostics());
+        
+
         DiagnosticsBag diagnostics = syntax.getDiagnostics();
 
         if(!diagnostics.isEmpty())
             return new EvaluationResult(diagnostics,null);
         
-        Evaluator evaluator = new Evaluator(boundExpression, variables);
+        Evaluator evaluator = new Evaluator(globalScope.getExpression(), variables);
         Object value = evaluator.evaluate();
         return new EvaluationResult(diagnostics, value);
     }

--- a/src/main/java/com/JsonAjax/justcompiler/Compilation.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Compilation.java
@@ -53,7 +53,7 @@ public class Compilation {
         if(!diagnostics.isEmpty())
             return new EvaluationResult(diagnostics,null);
         
-        Evaluator evaluator = new Evaluator(globalScope.getExpression(), variables);
+        Evaluator evaluator = new Evaluator(globalScope.getStatement(), variables);
         Object value = evaluator.evaluate();
         return new EvaluationResult(diagnostics, value);
     }

--- a/src/main/java/com/JsonAjax/justcompiler/Compilation.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Compilation.java
@@ -21,7 +21,7 @@ public class Compilation {
         Binder binder = new Binder(variables);
         BoundExpression boundExpression;
         try {
-            boundExpression = binder.bindExpression(syntax.getRoot());
+            boundExpression = binder.bindExpression(syntax.getRoot().getExpression());
         } catch (Exception e) {
             e.printStackTrace();
             return new EvaluationResult(binder.getDiagnostics(),null);

--- a/src/main/java/com/JsonAjax/justcompiler/DiagnosticsBag.java
+++ b/src/main/java/com/JsonAjax/justcompiler/DiagnosticsBag.java
@@ -1,7 +1,9 @@
 package com.JsonAjax.justcompiler;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import com.JsonAjax.justcompiler.Syntax.SyntaxKind;
@@ -19,6 +21,10 @@ public class DiagnosticsBag implements Iterable {
         this.diagnostics.addAll(diagnostics.diagnostics);
     }
     
+
+    public List<Diagnostic> toList(){
+        return new ArrayList<>(this.diagnostics);
+    }
 
     @Override
     public Iterator iterator() {
@@ -58,10 +64,14 @@ public class DiagnosticsBag implements Iterable {
     }
 
     public void reportUndefinedName(TextSpan span, String name) {
-        String message = "Variable " + name + " doesn't exist";
+        String message = "Variable " + name + " doesn't exist.";
         report(span, message);
     }
 
+    public void reportVariableCannotConvert(TextSpan span, Class fromType, Class toType) {
+        String message = "Cannot convert type '" + fromType + "' to type '" + toType + "'";
+        report(span, message);
+    }
 
     
 }

--- a/src/main/java/com/JsonAjax/justcompiler/DiagnosticsBag.java
+++ b/src/main/java/com/JsonAjax/justcompiler/DiagnosticsBag.java
@@ -47,7 +47,7 @@ public class DiagnosticsBag implements Iterable {
     }
 
     public void reportUndefindUnaryOperator(TextSpan span, String operatorText, Class operandType) {
-        String message = "Unary operator " + operatorText + " is not defined for type " + operandType;
+        String message = "Unary operator " + operatorText + " is not defined for type " + operandType +".";
         report(span, message);
     }
 
@@ -55,7 +55,7 @@ public class DiagnosticsBag implements Iterable {
         String message = "Binary operator " + operatorText
         + " is not defined for types " 
         + typeLeft + " and "
-        + typeRight;
+        + typeRight + ".";
         report(span, message);
     }
 
@@ -69,7 +69,17 @@ public class DiagnosticsBag implements Iterable {
     }
 
     public void reportVariableCannotConvert(TextSpan span, Class fromType, Class toType) {
-        String message = "Cannot convert type '" + fromType + "' to type '" + toType + "'";
+        String message = "Cannot convert type '" + fromType + "' to type '" + toType + "'.";
+        report(span, message);
+    }
+
+    public void reportVariableAlreadyDeclared(TextSpan span, String name) {
+        String message = "Variable '" + name + "' is already declared.'";
+        report(span, message);
+    }
+
+    public void reportCannotAssign(TextSpan span, String name) {
+        String message = "Variable '" + name + "' is read-only and cannotbe assigned to.";
         report(span, message);
     }
 

--- a/src/main/java/com/JsonAjax/justcompiler/Evaluator.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Evaluator.java
@@ -9,8 +9,11 @@ import java.util.Map;
 import com.JsonAjax.justcompiler.Binding.BoundAssignmentExpression;
 import com.JsonAjax.justcompiler.Binding.BoundBinaryExpression;
 import com.JsonAjax.justcompiler.Binding.BoundBinaryOperatorKind;
+import com.JsonAjax.justcompiler.Binding.BoundBlockStatement;
 import com.JsonAjax.justcompiler.Binding.BoundExpression;
+import com.JsonAjax.justcompiler.Binding.BoundExpressionStatement;
 import com.JsonAjax.justcompiler.Binding.BoundLiteralExpression;
+import com.JsonAjax.justcompiler.Binding.BoundStatement;
 import com.JsonAjax.justcompiler.Binding.BoundUnaryExpression;
 import com.JsonAjax.justcompiler.Binding.BoundUnaryOperatorKind;
 import com.JsonAjax.justcompiler.Binding.BoundVariableExpression;
@@ -21,16 +24,44 @@ import com.JsonAjax.justcompiler.Binding.BoundVariableExpression;
 public class Evaluator {
 
     private Map<VariableSymbol, Object> variables;
-    private BoundExpression root;
+    private BoundStatement root;
 
-    public Evaluator(BoundExpression root, Map<VariableSymbol, Object> variables) {
+    private Object lastValue;
+
+    public Evaluator(BoundStatement root, Map<VariableSymbol, Object> variables) {
         this.root = root;
         this.variables = variables;
     }
 
     public Object evaluate() {
-        return evaluateExpression(this.root);
+        evaluateStatement(root);
+        return lastValue;
+        //return evaluateExpression(this.root);
     } 
+
+    private void evaluateStatement(BoundStatement node) {
+        switch (node.getKind()) {
+            case blockStatment:
+                evaluateBlockStatement((BoundBlockStatement)node);
+                break;
+            case expressionStatement:
+                evaluateExpressionStatement((BoundExpressionStatement)node);
+                break;
+            
+            default:
+                throw new AssertionError("Unexpected Node " + node);
+        }
+    }
+
+    private void evaluateBlockStatement(BoundBlockStatement node) {
+        for (BoundStatement statement : node.getStatements()) {
+            evaluateStatement(statement);
+        }
+    }
+
+    private void evaluateExpressionStatement(BoundExpressionStatement node) {
+        lastValue = evaluateExpression(node.getExpression());
+    }
 
     private Object evaluateExpression(BoundExpression node) {
         switch (node.getKind()) {

--- a/src/main/java/com/JsonAjax/justcompiler/Evaluator.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Evaluator.java
@@ -16,6 +16,7 @@ import com.JsonAjax.justcompiler.Binding.BoundLiteralExpression;
 import com.JsonAjax.justcompiler.Binding.BoundStatement;
 import com.JsonAjax.justcompiler.Binding.BoundUnaryExpression;
 import com.JsonAjax.justcompiler.Binding.BoundUnaryOperatorKind;
+import com.JsonAjax.justcompiler.Binding.BoundVariableDeclaration;
 import com.JsonAjax.justcompiler.Binding.BoundVariableExpression;
 /**
  *
@@ -47,10 +48,19 @@ public class Evaluator {
             case expressionStatement:
                 evaluateExpressionStatement((BoundExpressionStatement)node);
                 break;
+            case BoundVariableDeclaration:
+                evaluateVariableDeclaration((BoundVariableDeclaration)node);
+                break;
             
             default:
                 throw new AssertionError("Unexpected Node " + node);
         }
+    }
+
+    private void evaluateVariableDeclaration(BoundVariableDeclaration node) {
+        Object value = evaluateExpression(node.getInitialiser());
+        variables.put(node.getVariable(), value);
+        lastValue = value;
     }
 
     private void evaluateBlockStatement(BoundBlockStatement node) {

--- a/src/main/java/com/JsonAjax/justcompiler/Index.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Index.java
@@ -38,7 +38,7 @@ public class Index {
     public static void main(String[] args) throws Exception {
 
         Map<VariableSymbol, Object> variables = new HashMap<>();
-
+        Compilation previous = null;
         StringBuilder textBuilder = new StringBuilder();
         Scanner in = new Scanner(System.in);
 
@@ -67,6 +67,12 @@ public class Index {
                     in.close();
                     System.exit(0);
                 }
+
+                else if (line.equals("#reset")) {
+                    previous = null;
+                    System.out.println("Terminal has been reset! all variables has been droped.#\n");
+                    continue;
+                }
             }
 
     
@@ -79,7 +85,9 @@ public class Index {
             if(!line.isBlank() && !line.isEmpty() && !ast.getDiagnostics().isEmpty())
                 continue;
 
-            Compilation compilation = new Compilation(ast);
+            Compilation compilation = previous == null? 
+                new Compilation(ast):
+                previous.continueWith(ast);
             EvaluationResult result = compilation.evaluate(variables);
 
             DiagnosticsBag diagnostics = result.getDiagnostics();
@@ -120,6 +128,7 @@ public class Index {
             } else {
                 System.out.println(ANSI_PURPLE + result.getValue() + ANSI_RESET);
                 System.out.println();
+                previous = compilation;
             }
 
             textBuilder = new StringBuilder();

--- a/src/main/java/com/JsonAjax/justcompiler/Index.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Index.java
@@ -46,9 +46,9 @@ public class Index {
         while (true) {
 
             if (textBuilder.length() == 0)
-                System.out.print("Just> ");
+                System.out.print(ANSI_GREEN + "Just> " + ANSI_RESET);
             else
-                System.out.print("|     ");
+                System.out.print(ANSI_GREEN + "|     " + ANSI_RESET);
 
             String line = in.nextLine();
             
@@ -118,7 +118,7 @@ public class Index {
 
                 }
             } else {
-                System.out.println("" + result.getValue());
+                System.out.println(ANSI_PURPLE + result.getValue() + ANSI_RESET);
                 System.out.println();
             }
 

--- a/src/main/java/com/JsonAjax/justcompiler/Index.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Index.java
@@ -70,7 +70,7 @@ public class Index {
 
                 else if (line.equals("#reset")) {
                     previous = null;
-                    System.out.println("Terminal has been reset! all variables has been droped.#\n");
+                    System.out.println("Terminal has been reset! all variables has been droped.\n");
                     continue;
                 }
             }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/BlockStatmentSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/BlockStatmentSyntax.java
@@ -1,0 +1,62 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlockStatmentSyntax extends StatementSyntax{
+    
+    private SyntaxToken openBraceToken;
+    private List<StatementSyntax> statements;
+    private SyntaxToken closeBraceToken;
+    
+    
+    public BlockStatmentSyntax(SyntaxToken openBraceToken, List<StatementSyntax> statements,
+            SyntaxToken closeBraceToken) {
+        this.openBraceToken = openBraceToken;
+        this.statements = statements;
+        this.closeBraceToken = closeBraceToken;
+    }
+
+
+    public SyntaxToken getOpenBraceToken() {
+        return openBraceToken;
+    }
+
+
+    public List<StatementSyntax> getStatements() {
+        return statements;
+    }
+
+
+    public SyntaxToken getCloseBraceToken() {
+        return closeBraceToken;
+    }
+
+
+    @Override
+    public SyntaxKind kind() {
+        return SyntaxKind.blockStatment;
+    }
+
+
+    @Override
+    public void prettyPrint(String indentation, PrintStream printStream) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'prettyPrint'");
+    }
+
+
+    @Override
+    public List<SyntaxNode> getChildren() {
+        List<SyntaxNode> children = new ArrayList<>();
+        children.add( openBraceToken);
+        children.addAll(statements);
+        children.add( closeBraceToken);
+        return children; 
+    }
+
+    
+
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/CompilationUnitSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/CompilationUnitSyntax.java
@@ -5,18 +5,18 @@ import java.util.List;
 
 public class CompilationUnitSyntax extends SyntaxNode {
 
-    private ExpressionSyntax expression;
+    private StatementSyntax statement;
     private SyntaxToken endOfFileToken;
 
     
 
-    public CompilationUnitSyntax(ExpressionSyntax expression, SyntaxToken endOfFileToken) {
-        this.expression = expression;
+    public CompilationUnitSyntax(StatementSyntax statement, SyntaxToken endOfFileToken) {
+        this.statement = statement;
         this.endOfFileToken = endOfFileToken;
     }
 
-    public ExpressionSyntax getExpression() {
-        return expression;
+    public StatementSyntax getStatement() {
+        return statement;
     }
 
     public SyntaxToken getEndOfFileToken() {
@@ -33,12 +33,12 @@ public class CompilationUnitSyntax extends SyntaxNode {
         printStream.println( "CompilationUnit");
         
         printStream.print(indentation+"└──");
-        expression.prettyPrint(indentation + "    ", printStream);
+        statement.prettyPrint(indentation + "    ", printStream);
     }
 
     @Override
     public List<SyntaxNode> getChildren() {
-        return List.of(expression);
+        return List.of(statement);
     }
     
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/CompilationUnitSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/CompilationUnitSyntax.java
@@ -1,0 +1,44 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+import java.io.PrintStream;
+import java.util.List;
+
+public class CompilationUnitSyntax extends SyntaxNode {
+
+    private ExpressionSyntax expression;
+    private SyntaxToken endOfFileToken;
+
+    
+
+    public CompilationUnitSyntax(ExpressionSyntax expression, SyntaxToken endOfFileToken) {
+        this.expression = expression;
+        this.endOfFileToken = endOfFileToken;
+    }
+
+    public ExpressionSyntax getExpression() {
+        return expression;
+    }
+
+    public SyntaxToken getEndOfFileToken() {
+        return endOfFileToken;
+    }
+
+    @Override
+    public SyntaxKind kind() {
+        return SyntaxKind.compilationUnit;
+    }
+
+    @Override
+    public void prettyPrint(String indentation, PrintStream printStream) {
+        printStream.println( "CompilationUnit");
+        
+        printStream.print(indentation+"└──");
+        expression.prettyPrint(indentation + "    ", printStream);
+    }
+
+    @Override
+    public List<SyntaxNode> getChildren() {
+        return List.of(expression);
+    }
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/ExpressionStatementSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/ExpressionStatementSyntax.java
@@ -1,0 +1,39 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+import java.io.PrintStream;
+import java.util.List;
+
+public class ExpressionStatementSyntax extends StatementSyntax {
+
+
+    ExpressionSyntax expression;
+
+    public ExpressionStatementSyntax(ExpressionSyntax expression) {
+        this.expression = expression;
+    }
+
+    
+
+    @Override
+    public SyntaxKind kind() {
+        return SyntaxKind.expressionStatment;
+    }
+
+    @Override
+    public void prettyPrint(String indentation, PrintStream printStream) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'prettyPrint'");
+    }
+
+    @Override
+    public List<SyntaxNode> getChildren() {
+       return List.of(expression);
+    }
+
+
+
+    public ExpressionSyntax getExpression() {
+        return expression;
+    }
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/Lexer.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/Lexer.java
@@ -81,6 +81,14 @@ public class Lexer {
                 this.kind = SyntaxKind.rightParen;
                 this.position++;
                 break;
+            case '{':
+                this.kind = SyntaxKind.leftBrace;
+                this.position++;
+                break;
+            case '}':
+                this.kind = SyntaxKind.rightBrace;
+                this.position++;
+                break;
 
             case '!':
                 if (lookahead() == '=') {

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
@@ -61,6 +61,33 @@ public class Parser {
         return parseAssignmentExpression();
     }
 
+    private StatementSyntax parseStatement(){
+        if (current().kind() == SyntaxKind.leftBrace)
+            return parseBlockStatement();
+        
+        return parseExpressionStatment();
+
+    }
+    
+    private StatementSyntax parseBlockStatement(){
+        List<StatementSyntax> statements = new ArrayList<>();
+        SyntaxToken leftBraceToken = matchToken(SyntaxKind.leftBrace);
+
+        while(current().kind() != SyntaxKind.endOfFile 
+            && current().kind() != SyntaxKind.rightBrace){
+                StatementSyntax statement = parseStatement();
+                statements.add(statement);
+        }
+
+        SyntaxToken rightBraceToken = matchToken(SyntaxKind.rightBrace);
+        return new BlockStatmentSyntax(leftBraceToken, statements, rightBraceToken);
+    }
+    
+    private StatementSyntax parseExpressionStatment(){
+        ExpressionSyntax expression = parseExpression();
+        return new ExpressionStatementSyntax(expression);
+    }
+
     private ExpressionSyntax parseAssignmentExpression(){
         if (peek(0).kind() == SyntaxKind.identifierToken &&
             peek(1).kind() == SyntaxKind.equals){
@@ -114,9 +141,9 @@ public class Parser {
     }
     
     public CompilationUnitSyntax parseCompilationUnit(){
-        ExpressionSyntax expressionSyntax = parseExpression();
+        StatementSyntax statementSyntax = parseStatement();
         SyntaxToken endOfFile = matchToken(SyntaxKind.endOfFile);
-        return new CompilationUnitSyntax(expressionSyntax, endOfFile);
+        return new CompilationUnitSyntax(statementSyntax, endOfFile);
     }
     
     private ExpressionSyntax parsePrimayExpression(){

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
@@ -113,10 +113,10 @@ public class Parser {
         return new SyntaxToken(kind, current().getPosition(), null, null);
     }
     
-    public SyntaxTree parse(){
+    public CompilationUnitSyntax parseCompilationUnit(){
         ExpressionSyntax expressionSyntax = parseExpression();
         SyntaxToken endOfFile = matchToken(SyntaxKind.endOfFile);
-        return new SyntaxTree(this.text, this.diagnostics, expressionSyntax, endOfFile);
+        return new CompilationUnitSyntax(expressionSyntax, endOfFile);
     }
     
     private ExpressionSyntax parsePrimayExpression(){
@@ -159,6 +159,7 @@ public class Parser {
     public DiagnosticsBag getDiagnostics() {
         return diagnostics; 
     }
+
     
     
     

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/Parser.java
@@ -62,13 +62,21 @@ public class Parser {
     }
 
     private StatementSyntax parseStatement(){
-        if (current().kind() == SyntaxKind.leftBrace)
-            return parseBlockStatement();
+
+        switch(current().kind()){
+            case leftBrace:
+                return parseBlockStatement();
+            case letKeyword:
+            case varKeyword:
+                return parseVariableDeclaration();
+            default:
+                return parseExpressionStatment();
+        }
         
-        return parseExpressionStatment();
+        
 
     }
-    
+
     private StatementSyntax parseBlockStatement(){
         List<StatementSyntax> statements = new ArrayList<>();
         SyntaxToken leftBraceToken = matchToken(SyntaxKind.leftBrace);
@@ -81,6 +89,15 @@ public class Parser {
 
         SyntaxToken rightBraceToken = matchToken(SyntaxKind.rightBrace);
         return new BlockStatmentSyntax(leftBraceToken, statements, rightBraceToken);
+    }
+
+    private StatementSyntax parseVariableDeclaration() {
+        SyntaxKind expected = current().kind() == SyntaxKind.letKeyword? SyntaxKind.letKeyword: SyntaxKind.varKeyword;
+        SyntaxToken keyword = matchToken(expected);
+        SyntaxToken identifier = matchToken(SyntaxKind.identifierToken);
+        SyntaxToken equals = matchToken(SyntaxKind.equals);
+        ExpressionSyntax initializer = parseExpression();
+        return new VariableDeclarationSyntax(keyword, identifier, equals, initializer);
     }
     
     private StatementSyntax parseExpressionStatment(){

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/StatementSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/StatementSyntax.java
@@ -1,0 +1,8 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+
+public abstract class StatementSyntax extends SyntaxNode {
+
+
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxFacts.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxFacts.java
@@ -85,6 +85,10 @@ public class SyntaxFacts {
                 return "(";
             case rightParen:
                 return ")";
+            case leftBrace:
+                return "{";
+            case rightBrace:
+                return "}";
             case bang:
                 return "!";
             case equals:

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxFacts.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxFacts.java
@@ -48,6 +48,10 @@ public class SyntaxFacts {
                 return SyntaxKind.trueKeyword;
             case "false":
                 return SyntaxKind.falseKeyword;
+            case "let":
+                return SyntaxKind.letKeyword;
+            case "var":
+                return SyntaxKind.varKeyword;
             default:
                 return SyntaxKind.identifierToken;
         }
@@ -105,6 +109,10 @@ public class SyntaxFacts {
                 return "false";
             case trueKeyword:
                 return "true";
+            case letKeyword:
+                return "let";
+            case varKeyword:
+                return "var";
             default:
                 return null;
         }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
@@ -28,7 +28,7 @@ public enum SyntaxKind {
     bangEquals, 
     equalsEquals,
 
-    //keywords
+    // keywords
     trueKeyword,
     falseKeyword,
     identifierToken,
@@ -39,5 +39,8 @@ public enum SyntaxKind {
     literalExpression, 
     parenthesizedExpression, 
     nameExpression, 
-    assignmentExpression, 
+    assignmentExpression,
+
+    // Nodes
+    compilationUnit,
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
@@ -27,11 +27,17 @@ public enum SyntaxKind {
     pipePipe,
     bangEquals, 
     equalsEquals,
+    leftBrace, 
+    rightBrace, 
 
     // keywords
     trueKeyword,
     falseKeyword,
     identifierToken,
+
+    // Statments
+    blockStatment,
+    expressionStatment, 
     
     // Expressions
     binaryExpression,
@@ -42,5 +48,5 @@ public enum SyntaxKind {
     assignmentExpression,
 
     // Nodes
-    compilationUnit,
+    compilationUnit, 
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxKind.java
@@ -28,16 +28,20 @@ public enum SyntaxKind {
     bangEquals, 
     equalsEquals,
     leftBrace, 
-    rightBrace, 
+    rightBrace,
+    identifierToken,
 
     // keywords
     trueKeyword,
     falseKeyword,
-    identifierToken,
+    letKeyword, 
+    varKeyword,
 
+    
     // Statments
     blockStatment,
-    expressionStatment, 
+    expressionStatment,
+    variableDeclaration, 
     
     // Expressions
     binaryExpression,
@@ -48,5 +52,5 @@ public enum SyntaxKind {
     assignmentExpression,
 
     // Nodes
-    compilationUnit, 
+    compilationUnit,   
 }

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxTree.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/SyntaxTree.java
@@ -16,18 +16,20 @@ import com.JsonAjax.justcompiler.Text.SourceText;
 public class SyntaxTree {
 
     private SourceText text;
-    private ExpressionSyntax root;
+    private CompilationUnitSyntax root;
     private SyntaxToken endOfFile;
     private DiagnosticsBag diagnostics;
 
-    public SyntaxTree(SourceText text, DiagnosticsBag diagnostics, ExpressionSyntax root, SyntaxToken endOfFile) {
+    private SyntaxTree(SourceText text) {
+        Parser parser = new Parser(text);
+        CompilationUnitSyntax root  =  parser.parseCompilationUnit();
+        diagnostics = parser.getDiagnostics();
+        
         this.root = root;
-        this.endOfFile = endOfFile;
-        this.diagnostics = diagnostics;
         this.text = text;
     }
 
-    public ExpressionSyntax getRoot() {
+    public CompilationUnitSyntax getRoot() {
         return root;
     }
 
@@ -40,15 +42,13 @@ public class SyntaxTree {
     }
 
     public static SyntaxTree parse(SourceText text){
-        Parser parser = new Parser(text);
-        return parser.parse();
+        return new SyntaxTree(text);
     }
     
 
     public static SyntaxTree parse(String text){
         SourceText sourceText = SourceText.from(text);
-        Parser parser = new Parser(sourceText);
-        return parser.parse();
+        return new SyntaxTree(sourceText);
     }
     
     public static List<SyntaxToken> parseTokens(SourceText text){

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/VariableDeclarationSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/VariableDeclarationSyntax.java
@@ -1,0 +1,57 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+import java.io.PrintStream;
+import java.util.List;
+
+public class VariableDeclarationSyntax extends StatementSyntax{
+
+    SyntaxToken keyword;
+    SyntaxToken identifier;
+    SyntaxToken equalsToken;
+    ExpressionSyntax initializer;
+    
+
+    public SyntaxToken getKeyword() {
+        return keyword;
+    }
+
+    public SyntaxToken getIdentifier() {
+        return identifier;
+    }
+
+    public SyntaxToken getEqualsToken() {
+        return equalsToken;
+    }
+
+    public ExpressionSyntax getInitializer() {
+        return initializer;
+    }
+
+    public VariableDeclarationSyntax(SyntaxToken keyword, SyntaxToken identifier, SyntaxToken equalsToken,
+            ExpressionSyntax initializer) {
+        this.keyword = keyword;
+        this.identifier = identifier;
+        this.equalsToken = equalsToken;
+        this.initializer = initializer;
+    }
+
+    @Override
+    public SyntaxKind kind() {
+        return SyntaxKind.variableDeclaration;
+    }
+
+    @Override
+    public void prettyPrint(String indentation, PrintStream printStream) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'prettyPrint'");
+    }
+
+    @Override
+    public List<SyntaxNode> getChildren() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getChildren'");
+    }
+
+
+    
+}

--- a/src/main/java/com/JsonAjax/justcompiler/Text/SourceText.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Text/SourceText.java
@@ -63,7 +63,7 @@ public final class SourceText {
             }
         }
 
-        if(position>lineStart){
+        if(position>=lineStart){
             addLine(lines, sourceText, lineStart, position, 0);
         }
 

--- a/src/main/java/com/JsonAjax/justcompiler/VariableSymbol.java
+++ b/src/main/java/com/JsonAjax/justcompiler/VariableSymbol.java
@@ -3,11 +3,13 @@ package com.JsonAjax.justcompiler;
 public class VariableSymbol {
     private String name;
     private Class type;
+    private boolean isReadOnly;
 
 
-    public VariableSymbol(String name, Class type) {
+    public VariableSymbol(String name, boolean isReadOnly ,Class type) {
         this.name = name;
         this.type = type;
+        this.isReadOnly = isReadOnly;
     }
 
 
@@ -18,6 +20,11 @@ public class VariableSymbol {
 
     public Class getType() {
         return type;
+    }
+
+
+    public boolean isReadOnly() {
+        return isReadOnly;
     }
 
     

--- a/src/test/java/com/JsonAjax/justcompiler/EvaluationTest.java
+++ b/src/test/java/com/JsonAjax/justcompiler/EvaluationTest.java
@@ -58,7 +58,7 @@ public class EvaluationTest {
             Arguments.of("true || true", true),
             Arguments.of("true || false", true),
             
-            Arguments.of("(a = 10) * a", 100)
+            Arguments.of("{var a = 0 (a = 10) * a}", 100)
         );
         
         return list.stream();

--- a/src/test/java/com/JsonAjax/justcompiler/Syntax/ParserTest.java
+++ b/src/test/java/com/JsonAjax/justcompiler/Syntax/ParserTest.java
@@ -28,6 +28,7 @@ public class ParserTest {
 
         if (op1precedence >= op2precedence){
             AssertingList e = new AssertingList(ast.getRoot());
+            e.AssertNode(SyntaxKind.compilationUnit);
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.nameExpression);
@@ -42,6 +43,7 @@ public class ParserTest {
 
         }else {
             AssertingList e = new AssertingList(ast.getRoot());
+            e.AssertNode(SyntaxKind.compilationUnit);
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.nameExpression);
             e.AssertToken(SyntaxKind.identifierToken, "a");
@@ -70,6 +72,7 @@ public class ParserTest {
 
         if (unaryPrecedence >= binaryPrecedence){
             AssertingList e = new AssertingList(ast.getRoot());
+            e.AssertNode(SyntaxKind.compilationUnit);
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.unaryExpression);
             e.AssertToken(unaryKind, unaryText);
@@ -83,7 +86,7 @@ public class ParserTest {
 
         }else {
             AssertingList e = new AssertingList(ast.getRoot());
-            
+            e.AssertNode(SyntaxKind.compilationUnit);
             e.AssertNode(SyntaxKind.unaryExpression);
             e.AssertToken(unaryKind, unaryText);
             e.AssertNode(SyntaxKind.binaryExpression);   

--- a/src/test/java/com/JsonAjax/justcompiler/Syntax/ParserTest.java
+++ b/src/test/java/com/JsonAjax/justcompiler/Syntax/ParserTest.java
@@ -26,9 +26,12 @@ public class ParserTest {
         String text = "a "+ op1Text + " b " + op2Text + " c";
         SyntaxTree ast = SyntaxTree.parse(text);
 
+        AssertingList e = new AssertingList(ast.getRoot());
+        e.AssertNode(SyntaxKind.compilationUnit);
+        e.AssertNode(SyntaxKind.expressionStatment);
+       
         if (op1precedence >= op2precedence){
-            AssertingList e = new AssertingList(ast.getRoot());
-            e.AssertNode(SyntaxKind.compilationUnit);
+
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.nameExpression);
@@ -42,8 +45,7 @@ public class ParserTest {
 
 
         }else {
-            AssertingList e = new AssertingList(ast.getRoot());
-            e.AssertNode(SyntaxKind.compilationUnit);
+
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.nameExpression);
             e.AssertToken(SyntaxKind.identifierToken, "a");
@@ -69,10 +71,13 @@ public class ParserTest {
         String text = unaryText + " a " + binaryText + " b";
         
         SyntaxTree ast = SyntaxTree.parse(text);
-
+        AssertingList e = new AssertingList(ast.getRoot());
+        
+        e.AssertNode(SyntaxKind.compilationUnit);
+        e.AssertNode(SyntaxKind.expressionStatment);
+        
         if (unaryPrecedence >= binaryPrecedence){
-            AssertingList e = new AssertingList(ast.getRoot());
-            e.AssertNode(SyntaxKind.compilationUnit);
+            
             e.AssertNode(SyntaxKind.binaryExpression);
             e.AssertNode(SyntaxKind.unaryExpression);
             e.AssertToken(unaryKind, unaryText);
@@ -85,8 +90,7 @@ public class ParserTest {
 
 
         }else {
-            AssertingList e = new AssertingList(ast.getRoot());
-            e.AssertNode(SyntaxKind.compilationUnit);
+
             e.AssertNode(SyntaxKind.unaryExpression);
             e.AssertToken(unaryKind, unaryText);
             e.AssertNode(SyntaxKind.binaryExpression);   

--- a/src/test/java/com/JsonAjax/justcompiler/Syntax/SourceTextTest.java
+++ b/src/test/java/com/JsonAjax/justcompiler/Syntax/SourceTextTest.java
@@ -1,0 +1,31 @@
+package com.JsonAjax.justcompiler.Syntax;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.JsonAjax.justcompiler.Text.SourceText;
+
+public class SourceTextTest {
+
+    @ParameterizedTest
+    @MethodSource("linesData")
+    public void SourceText_IncludesLastLine(String text, int expectedLineCount){
+        SourceText sourceText = SourceText.from(text);
+        assertEquals(expectedLineCount, sourceText.getLines().size());
+    }
+
+
+    private static Stream<Arguments> linesData(){
+        return Stream.of(
+            Arguments.of(".",1),
+            Arguments.of(".\r\n",2),
+            Arguments.of(".\r\n\r\n",3)
+        );
+    }
+    
+}


### PR DESCRIPTION
It is now possible to use blocks and properly declare variables using the key word "var". The output is the result of the last expression

It is also possible to declare variable in read only mode using the key word "let":




"Just" now support proper scoping, it is not possible to re-declare variable in the same scope or to aces variable out of 