### PR TITLE
Fix #showTree command for "for" statements

### DIFF
--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/ForStatementSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/ForStatementSyntax.java
@@ -61,7 +61,7 @@ public class ForStatementSyntax extends StatementSyntax{
 
     @Override
     public List<SyntaxNode> getChildren() {
-        return List.of(forkeyword,identifier,equalsToken,lowerbound,upperbound);
+        return List.of(forkeyword,identifier,equalsToken,lowerbound,toKeyword,upperbound,body);
     }
 
     


### PR DESCRIPTION
Fix an issue where the command #showTree does not diplay correctly the elements of a for statement