### PR TITLE
Fix #showTree command for "for" statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mycompany</groupId>
     <artifactId>JustCompiler</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>0.5.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>

--- a/src/main/java/com/JsonAjax/justcompiler/Syntax/ForStatementSyntax.java
+++ b/src/main/java/com/JsonAjax/justcompiler/Syntax/ForStatementSyntax.java
@@ -61,7 +61,7 @@ public class ForStatementSyntax extends StatementSyntax{
 
     @Override
     public List<SyntaxNode> getChildren() {
-        return List.of(forkeyword,identifier,equalsToken,lowerbound,upperbound);
+        return List.of(forkeyword,identifier,equalsToken,lowerbound,toKeyword,upperbound,body);
     }
 
     


### PR DESCRIPTION
Fix an issue where the command #showTree does not diplay correctly the elements of a for statement